### PR TITLE
fix: clear perspective-sensitive animations on spectate target switch

### DIFF
--- a/src/ui/roomscene.h
+++ b/src/ui/roomscene.h
@@ -448,6 +448,8 @@ private:
     // animation related functions
     typedef void (RoomScene::*AnimationFunc)(const QString &, const QStringList &);
     QGraphicsObject *getAnimationObject(const QString &name) const;
+    static const int S_DATA_PERSPECTIVE_ANIMATION = 9531;
+    void clearPerspectiveSensitiveAnimations();
 
     void doMovingAnimation(const QString &name, const QStringList &args);
     void doAppearingAnimation(const QString &name, const QStringList &args);


### PR DESCRIPTION
Indicator lines, moving animations, and appearing animations capture absolute scene coordinates at creation time. When the spectating target switches mid-animation, the seat layout is rearranged but the in-flight animations still reference stale coordinates, causing them to visually point at wrong players.

Add clearPerspectiveSensitiveAnimations() that removes all active IndicatorItem instances (via dynamic_cast) and tagged animation items (via S_DATA_PERSPECTIVE_ANIMATION data key) from the scene. Call it at the top of both enterPerspectiveView() and exitPerspectiveView(), before any seat swap or rotation occurs.